### PR TITLE
Fix images becoming undraggable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "rank-up-site",
-	"version": "0.3.0",
+	"version": "0.3.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "rank-up-site",
-			"version": "0.3.0",
+			"version": "0.3.2",
 			"dependencies": {
 				"sortablejs": "^1.15.7"
 			},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rank-up-site",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",

--- a/src/pages/rankup/rankup.ts
+++ b/src/pages/rankup/rankup.ts
@@ -350,13 +350,14 @@ function makeRowsDrag(): void {
 	const rowList = document.getElementById("rowList");
 	if (!rowList) throw new Error("Could not enable row dragging. rowList was not found.");
 
-	let rowSortable = new Sortable(rowList, {
+	new Sortable(rowList, {
 		draggable: ".rowFull", // The thing to be dragged
 		handle: ".dragContainer", // The thing to grab to drag by
 		direction: "vertical",
 		animation: 180,
 		easing: "cubic-bezier(0.22,1,0.36,1)",
 		ghostClass: "rowSortGhost",
+		ignore: "a",
 		onStart(event) {
 			isRowBeingDragged = true;
 			// Add the dragging class for styling


### PR DESCRIPTION
Fixed images being undraggable. By default, SortableJS disables images being draggable when its parent is dragged.

Fixes #94